### PR TITLE
Add tests for week-3/02-course-app-easy-2

### DIFF
--- a/week-3/02-course-app-easy-2/index.js
+++ b/week-3/02-course-app-easy-2/index.js
@@ -49,6 +49,4 @@ app.get('/users/purchasedCourses', (req, res) => {
   // logic to view purchased courses
 });
 
-app.listen(3000, () => {
-  console.log('Server is listening on port 3000');
-});
+module.exports = app;

--- a/week-3/02-course-app-easy-2/index.test.js
+++ b/week-3/02-course-app-easy-2/index.test.js
@@ -1,0 +1,529 @@
+const http = require("http");
+const server = require("./index");
+const jsonwebtoken = require("jsonwebtoken");
+
+const username = "testuser";
+const password = "testpassword";
+
+describe("API Tests", () => {
+  let globalServer;
+  let courseId;
+  let adminToken;
+  let userToken;
+
+  beforeAll((done) => {
+    if (globalServer) {
+      globalServer.close();
+    }
+    globalServer = server.listen(3000);
+    done();
+  });
+
+  afterAll((done) => {
+    globalServer.close(done);
+  });
+
+  it("should allow users to signup", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/users/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(201);
+
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).toBe("User created successfully");
+    expect(responseBody.token.length).toBeTruthy();
+
+    const token = responseBody.token;
+    expect(isValidJWT(token)).toBeTruthy();
+
+    userToken = token;
+  });
+
+  it("should allow admins to signup and test validity of jwt", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(201);
+
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).toBe("Admin created successfully");
+    expect(responseBody.token.length).toBeTruthy();
+
+    const token = responseBody.token;
+    expect(isValidJWT(token)).toBeTruthy();
+  });
+
+  it("shouldn't allow duplicate usernames for admins", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("shouldn't allow admins to signup with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: username });
+
+    const options = {
+      method: "POST",
+      path: "/admin/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should allow admins to login", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).toBe("Logged in successfully");
+    expect(responseBody.token.length).toBeTruthy();
+
+    // test validity of jwt
+    const token = responseBody.token;
+    expect(isValidJWT(token)).toBeTruthy();
+
+    adminToken = token;
+  });
+
+  it("shouldn't allow admins to login on invalid credentials", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: "incorrectPass",
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("shouldn't allow admins to login with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: username });
+
+    const options = {
+      method: "POST",
+      path: "/admin/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should allow admins to create courses", async () => {
+    const requestBody = JSON.stringify({
+      title: "course title",
+      description: "course description",
+      price: 100,
+      imageLink: "https://linktoimage.com",
+      published: true,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/courses",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(201);
+
+    const responseBody = JSON.parse(response.body);
+
+    expect(responseBody.message).toBe("Course created successfully");
+    expect(responseBody.courseId).toBeTruthy();
+
+    courseId = responseBody.courseId;
+  });
+
+  it("should not allow users to access admin routes", async () => {
+    const requestBody = JSON.stringify({
+      title: "course title",
+      description: "course description",
+      price: 100,
+      imageLink: "https://linktoimage.com",
+      published: true,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/admin/courses",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("should allow admins to update courses", async () => {
+    const requestBody = JSON.stringify({
+      title: "updated course title",
+      description: "updated course description",
+      price: 100,
+      imageLink: "https://linktoimage.com",
+      published: true,
+    });
+
+    const options = {
+      method: "PUT",
+      path: `/admin/courses/${courseId}`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: "Course updated successfully" })
+    );
+  });
+
+  it("should send 404 on updating invalid courseId", async () => {
+    const requestBody = JSON.stringify({
+      title: "updated course title",
+      description: "updated course description",
+      price: 100,
+      imageLink: "https://linktoimage.com",
+      published: true,
+    });
+
+    const options = {
+      method: "PUT",
+      path: `/admin/courses/invald-course-id`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("admins should get courses", async () => {
+    const options = {
+      method: "GET",
+      path: `/admin/courses`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).length).toBeTruthy();
+  });
+
+  it("users should get courses", async () => {
+    const options = {
+      method: "GET",
+      path: `/users/courses`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).length).toBeTruthy();
+  });
+
+  it("non authorized users shouldn't get courses", async () => {
+    const options = {
+      method: "GET",
+      path: `/users/courses`,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("shouldn't allow duplicate usernames for users", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/users/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("shouldn't allow users to signup with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: username });
+
+    const options = {
+      method: "POST",
+      path: "/users/signup",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should allow users to login", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: password,
+    });
+
+    const options = {
+      method: "POST",
+      path: "/users/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).toBe("Logged in successfully");
+    expect(responseBody.token.length).toBeTruthy();
+
+    // test validity of jwt
+    const token = responseBody.token;
+    expect(isValidJWT(token)).toBeTruthy();
+  });
+
+  it("shouldn't allow users to login on invalid credentials", async () => {
+    const requestBody = JSON.stringify({
+      username: username,
+      password: "incorrectPass",
+    });
+
+    const options = {
+      method: "POST",
+      path: "/users/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("shouldn't allow users to login with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: username });
+
+    const options = {
+      method: "POST",
+      path: "/users/login",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should allow users to purchase courses", async () => {
+    const options = {
+      method: "POST",
+      path: `/users/courses/${courseId}`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+
+    const responseBody = JSON.parse(response.body);
+
+    expect(responseBody.message).toBe("Course purchased successfully");
+  });
+
+  it("should send 404 on purchasing course with invalid courseId", async () => {
+    const options = {
+      method: "POST",
+      path: `/users/courses/invald-course-id`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("should allow users to get purchased courses", async () => {
+    const options = {
+      method: "GET",
+      path: `/users/purchasedCourses`,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).length).toBeTruthy();
+  });
+});
+
+function isValidJWT(token) {
+  try {
+    const decoded = jsonwebtoken.decode(token);
+
+    if (decoded) {
+      const currentTimestamp = Math.floor(Date.now() / 1000);
+      const expiresIn = decoded.exp - currentTimestamp;
+
+      // check if JWT expires with in an hour
+      if (expiresIn <= 3600) {
+        return true;
+      }
+    }
+    return false;
+  } catch (e) {
+    return false;
+  }
+}
+
+function sendRequest(options, requestBody) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        ...options,
+        host: "localhost",
+        port: 3000,
+      },
+      (res) => {
+        let body = "";
+
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body,
+          });
+        });
+      }
+    );
+
+    req.on("error", (err) => {
+      reject(err);
+    });
+
+    if (requestBody) {
+      req.write(requestBody);
+    }
+
+    req.end();
+  });
+}

--- a/week-3/02-course-app-easy-2/package.json
+++ b/week-3/02-course-app-easy-2/package.json
@@ -4,9 +4,16 @@
   "description": "### Description 1. Admins should be able to sign up 2. Admins should be able to create courses    1. Course has a title, description, price, and image link    2. Course should be able to be published or unpublished 3. Admins should be able to edit courses 4. Users should be able to sign up 5. Users should be able to purchase courses 6. Users should be able to view purchased courses 7. Users should be able to view all courses",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/jest/bin/jest.js ./index.test.js"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.5.0"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2"
+  }
 }


### PR DESCRIPTION
This MR adds the following test to week-3/02-course-app-easy-2

- should allow users to signup
- should allow admins to signup and test validity of jwt
- shouldn't allow duplicate usernames for admins
 - shouldn't allow admins to signup with bad request body
- should allow admins to login
- shouldn't allow admins to login on invalid credentials
- shouldn't allow admins to login with bad request body
- should allow admins to create courses
- should not allow users to access admin routes
- should allow admins to update courses
- should send 404 on updating invalid courseId
- admins should get courses
- users should get courses
- non-authorized users shouldn't get courses
- shouldn't allow duplicate usernames for users
- shouldn't allow users to signup with bad request body
- should allow users to login
- shouldn't allow users to login on invalid credentials
- shouldn't allow users to login with bad request body
- should allow users to purchase courses
- should send 404 on purchasing course with invalid courseId
- should allow users to get purchased courses
